### PR TITLE
escape if there are special chars in the column names

### DIFF
--- a/fudgeo/geopkg.py
+++ b/fudgeo/geopkg.py
@@ -517,7 +517,7 @@ class Field:
         Escaped Name, only adds quotes if needed
         """
         name = self.name
-        if name.upper() in KEYWORDS:
+        if name.upper() in KEYWORDS or any((c in set('.-/[]()')) for c in name):
             name = f'"{name}"'
         return name
     # End escaped_name property


### PR DESCRIPTION
escape if there are special chars in the column names (mostly for "." and "-")